### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/ias-guided-packaging-introduction.md
+++ b/doc/ias-guided-packaging-introduction.md
@@ -56,7 +56,7 @@ Run this:
 You will be asked questions:
 
 <pre>Required:
-Package name: my-first-ias-package
+Package name: my_first_ias_package
 Required:
 Short summary: This is the first package I've built at IAS.
 Wiki page: https://www.net.ias.edu


### PR DESCRIPTION
Marty, your documentation stated that the project name should contain dashes, when in actuality, dashes are prohibited.

```
$ /opt/IAS/bin/ias-package-shell/package_shell.pl
Project names must not begin with numbers.
Project names must not contain whitespace or dashes.
Example: some_project_name
Required:
Project name: ias-notify-dns-change 
Project names must not begin with numbers.
Project names must not contain whitespace or dashes.
```

This is a quick fix of the documentation.